### PR TITLE
Point README usage examples at doist fork

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This GitHub Action updates existing CloudFormation stack by changing some of its
 ## Usage
 
 ```yaml
-- uses: artyom/update-cloudformation-stack@main
+- uses: doist/update-cloudformation-stack@main
   with:
     stack: my-stack-name
     parameters: |
@@ -49,7 +49,7 @@ jobs:
         with:
           role-to-assume: arn:aws:iam::123456789012:role/my-role
           aws-region: us-east-1
-      - uses: artyom/update-cloudformation-stack@main
+      - uses: doist/update-cloudformation-stack@main
         with:
           stack: production-stack
           parameters: |


### PR DESCRIPTION
Update the README examples from `artyom/update-cloudformation-stack@main` to `doist/update-cloudformation-stack@main` so they match how the org consumes this action.